### PR TITLE
Correzione errore formattazione grassetto in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ Le **normative di versione 2.00** (elencate nella tabella di seguito), sono anco
 
 
 
-Le **normative di versione 3.00 e 3.01 **(nelle due tabelle che seguono) costituiscono l'apparato di schede ad oggi più completo ed aggiornato:
+Le **normative di versione 3.00 e 3.01** (nelle due tabelle che seguono) costituiscono l'apparato di schede ad oggi più completo ed aggiornato:
 
 
 <table>


### PR DESCRIPTION
Nel file README.md è presente un errore di formattazione

![image](https://user-images.githubusercontent.com/16253859/52169408-12e28e00-2738-11e9-955f-94f9aefae656.png)
